### PR TITLE
add sections to provide optional Spot VM provision

### DIFF
--- a/supported/standalone/1nic/existing-stack/byol/f5-existing-stack-byol-1nic-bigip.py
+++ b/supported/standalone/1nic/existing-stack/byol/f5-existing-stack-byol-1nic-bigip.py
@@ -106,8 +106,11 @@ def Instance(context, mgmtSharedVpc):
               ]
             },
             'zone': context.properties['availabilityZone1'],
-            'metadata': Metadata(context)
-
+            'metadata': Metadata(context),
+            # adding scheduling section in order to optionally create Spot VM
+            'scheduling': {
+                'provisioningModel': context.properties['provisioningModel']
+            }
         }
     }
 

--- a/supported/standalone/1nic/existing-stack/byol/f5-existing-stack-byol-1nic-bigip.yaml
+++ b/supported/standalone/1nic/existing-stack/byol/f5-existing-stack-byol-1nic-bigip.yaml
@@ -38,6 +38,8 @@ resources:
    restrictedSrcAddressApp:
    ### (OPTIONAL) Provision Public IP addresses for BIG-IP Network Interfaces. By default it is set to provision public IPs.
    provisionPublicIP: yes
+   ### (REQUIRED) Change the default 'STANDARD' to 'SPOT', if you want to provision Spot VM (https://cloud.google.com/compute/docs/instances/spot)
+   provisioningModel: STANDARD
    ### If you would like to view all available images, run the following command from the **gcloud** command line: ```$ gcloud compute images list --project f5-7626-networks-public | grep f5```
    ### (OPTIONAL) BIG-IP image, valid choices include:
 


### PR DESCRIPTION
@<reviewer_id>

#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
No issue was created yet, it was my own requirement to be able to deploy Spot VM, to save costs. I'm using this deployment for lab and learning purposes and for me it makes sense to save cost with this feature.

#### What's this change do?
It will add option to deploy the VM as Spot VM in Google Cloud in order to save cost
#### Where should the reviewer start?
line 110 in f5-existing-stack-byol-1nic-bigip.py 
line 42 in f5-existing-stack-byol-1nic-bigip.yaml
#### Any background context?
https://cloud.google.com/compute/docs/instances/spot